### PR TITLE
Disable Doze & App standby

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -94,4 +94,9 @@
     <!-- Force to landscape -->
     <bool name="config_forceDefaultOrientation">true</bool>
 
+    <!-- Disable Doze & App Standby -->
+    <!-- In a car we don't care about battery life, nor about an eventuality of critical background
+         jobs stopping due to policies invented to lower power consumptions on mobile phones -->
+     <bool name="config_enableAutoPowerModes">false</bool>
+
 </resources>


### PR DESCRIPTION
 * it's not something we have to care about, and will save us from having to care about manually whitelisting any app we want to be running at all times and not affected by battery saving policies